### PR TITLE
Add the basic redirect index.html to the esp-usb-bridge wiki page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,7 @@
+<html>
+
+<head>
+    <meta http-equiv="Refresh" content="0; url='https://github.com/espressif/esp-usb-bridge/wiki/ESP-Prog-2-firmware-update-guide'" />
+</head>
+
+</html>


### PR DESCRIPTION
This adds the `inxed.html` required for GitHub pages to redirect to our `esp-usb-bridge` wiki page about updating the firmware on the ESP Prog 2.